### PR TITLE
perf: Vercel cost and load time optimizations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+node_modules
+build
+public/build
+.cache
+coverage
+api/index.js

--- a/app/components/cookie-consent.tsx
+++ b/app/components/cookie-consent.tsx
@@ -7,13 +7,14 @@ interface Script {
   src?: string
 }
 
-function GoogleScripts() {
-  const [added, setAdded] = useState(false)
+let scriptsInjected = false
 
+function GoogleScripts() {
   useEffect(() => {
-    if (added) {
+    if (scriptsInjected) {
       return
     }
+    scriptsInjected = true
 
     const scripts: Script[] = [
       {
@@ -56,9 +57,7 @@ function GoogleScripts() {
 
       document.head.appendChild(element)
     })
-
-    setAdded(true)
-  }, [added])
+  }, [])
 
   return null
 }

--- a/app/components/ui/pagination.tsx
+++ b/app/components/ui/pagination.tsx
@@ -6,7 +6,8 @@ import {
 } from "@radix-ui/react-icons"
 
 import { cn } from "~/lib/utils"
-import { ButtonProps, buttonVariants } from "~/components/ui/button"
+import type { ButtonProps} from "~/components/ui/button";
+import { buttonVariants } from "~/components/ui/button"
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav
@@ -44,6 +45,7 @@ type PaginationLinkProps = {
   React.ComponentProps<"a">
 
 const PaginationLink = ({
+  children,
   className,
   isActive,
   size = "icon",
@@ -59,7 +61,9 @@ const PaginationLink = ({
       className
     )}
     {...props}
-  />
+  >
+    {children}
+  </a>
 )
 PaginationLink.displayName = "PaginationLink"
 

--- a/app/db/index.ts
+++ b/app/db/index.ts
@@ -9,7 +9,12 @@ async function ensureIndexes(mongoClient: any): Promise<void> {
   indexesEnsured = true
   const databaseName = process.env.DB_DATABASE ?? ''
   const db = mongoClient.db(databaseName)
-  await db.collection('games').createIndex({ grossRevenue: -1 }, { background: true })
+  const games = db.collection('games')
+  await Promise.all([
+    games.createIndex({ grossRevenue: -1 }, { background: true }),
+    games.createIndex({ gameId: 1 }, { background: true, unique: true }),
+    games.createIndex({ name: 1 }, { background: true })
+  ])
 }
 
 export async function getCollection(collectionName: string) {

--- a/app/models/game.ts
+++ b/app/models/game.ts
@@ -1,5 +1,5 @@
 import { BaseModel } from 'esix'
-import { GameDetails } from '~/games'
+import type { GameDetails } from '~/games'
 
 export class Game extends BaseModel {
   details?: GameDetails

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -21,6 +21,9 @@ export const links: LinksFunction = () => [
     href: 'https://fonts.gstatic.com',
     crossOrigin: 'anonymous'
   },
+  { rel: 'dns-prefetch', href: 'https://www.googletagmanager.com' },
+  { rel: 'dns-prefetch', href: 'https://pagead2.googlesyndication.com' },
+  { rel: 'dns-prefetch', href: 'https://cdn.akamai.steamstatic.com' },
   ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : []),
   { rel: 'stylesheet', href: tailwind },
   { rel: 'stylesheet', href: styles },

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,11 +1,11 @@
-import type { HeadersFunction, V2_MetaFunction } from '@remix-run/node'
-import { LoaderFunction } from '@remix-run/node'
+import type { HeadersFunction, V2_MetaFunction , LoaderFunction } from '@remix-run/node'
+
 import { Link, useLoaderData } from '@remix-run/react'
 import { useState } from 'react'
 import slugify from 'slugify'
 
 import { Page } from '~/components/page'
-import { GameDetails } from '~/games'
+import type { GameDetails } from '~/games'
 import { calculateRevenue, revenueBreakdown } from '~/revenue'
 import { RevenueBreakdownTable } from '~/revenue/revenue-breakdown-table'
 import { GameService } from '~/services/game-service.server'

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { V2_MetaFunction } from '@remix-run/node'
+import type { HeadersFunction, V2_MetaFunction } from '@remix-run/node'
 import { LoaderFunction } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
 import { useState } from 'react'
@@ -41,6 +41,12 @@ export const meta: V2_MetaFunction = () => {
       href: 'https://steam-revenue-calculator.com/'
     }
   ]
+}
+
+export const headers: HeadersFunction = () => {
+  return {
+    'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-while-revalidate=86400'
+  }
 }
 
 export const loader: LoaderFunction = async () => {

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -1,7 +1,13 @@
-import type { V2_MetaFunction } from '@remix-run/node'
+import type { HeadersFunction, V2_MetaFunction } from '@remix-run/node'
 import type { ReactElement } from 'react'
 
 import { Page } from '~/components/page'
+
+export const headers: HeadersFunction = () => {
+  return {
+    'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800'
+  }
+}
 
 export const meta: V2_MetaFunction = () => {
   return [

--- a/app/routes/api.migrate-games.ts
+++ b/app/routes/api.migrate-games.ts
@@ -6,8 +6,9 @@ import { GameService } from '~/services/game-service.server'
 export const loader: LoaderFunction = async ({ request }) => {
   const url = new URL(request.url)
   const key = url.searchParams.get('key')
+  const expectedKey = process.env.SCRAPE_KEY
 
-  if (!key || key !== 'YTViNDlkMGMtNTZiYi00Y2ExLWFhOGItZmE5NDNhM2E3ZWYyIA') {
+  if (!expectedKey || !key || key !== expectedKey) {
     return new Response('Unauthorized.', { status: 401 })
   }
 

--- a/app/routes/api.scrape-games.ts
+++ b/app/routes/api.scrape-games.ts
@@ -13,8 +13,9 @@ export const loader: LoaderFunction = async ({ request }) => {
   const url = new URL(request.url)
   const key = url.searchParams.get('key')
   const cursor = parseInt(url.searchParams.get('cursor') ?? '1', 10)
+  const expectedKey = process.env.SCRAPE_KEY
 
-  if (!key || key !== 'YTViNDlkMGMtNTZiYi00Y2ExLWFhOGItZmE5NDNhM2E3ZWYyIA') {
+  if (!expectedKey || !key || key !== expectedKey) {
     return new Response('Unauthorized.', { status: 401 })
   }
 

--- a/app/routes/app.$id.$slug.tsx
+++ b/app/routes/app.$id.$slug.tsx
@@ -1,4 +1,4 @@
-import type { LoaderFunction, V2_MetaFunction } from '@remix-run/node'
+import type { HeadersFunction, LoaderFunction, V2_MetaFunction } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
 import type { ReactElement } from 'react'
 import slugify from 'slugify'
@@ -12,6 +12,12 @@ import { RevenueBreakdownTable } from '~/revenue/revenue-breakdown-table'
 
 interface LoaderData {
   game: GameDetails
+}
+
+export const headers: HeadersFunction = () => {
+  return {
+    'Cache-Control': 'public, max-age=300, s-maxage=86400, stale-while-revalidate=604800'
+  }
 }
 
 export const loader: LoaderFunction = async ({

--- a/app/routes/blog._index.tsx
+++ b/app/routes/blog._index.tsx
@@ -1,6 +1,6 @@
 import type { HeadersFunction } from '@remix-run/node'
 import { Link } from '@remix-run/react'
-import { ReactElement } from 'react'
+import type { ReactElement } from 'react'
 
 export const headers: HeadersFunction = () => {
   return {

--- a/app/routes/blog._index.tsx
+++ b/app/routes/blog._index.tsx
@@ -1,5 +1,12 @@
+import type { HeadersFunction } from '@remix-run/node'
 import { Link } from '@remix-run/react'
 import { ReactElement } from 'react'
+
+export const headers: HeadersFunction = () => {
+  return {
+    'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800'
+  }
+}
 
 export default function BlogRoute(): ReactElement {
   return (

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -1,8 +1,14 @@
-import type { LinksFunction, V2_MetaFunction } from '@remix-run/node'
+import type { HeadersFunction, LinksFunction, V2_MetaFunction } from '@remix-run/node'
 import { Outlet } from '@remix-run/react'
 import type { ReactElement } from 'react'
 
 import { Page } from '~/components/page'
+
+export const headers: HeadersFunction = () => {
+  return {
+    'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800'
+  }
+}
 
 export const meta: V2_MetaFunction = () => {
   return [

--- a/app/routes/blog.tsx
+++ b/app/routes/blog.tsx
@@ -1,4 +1,4 @@
-import type { HeadersFunction, LinksFunction, V2_MetaFunction } from '@remix-run/node'
+import type { HeadersFunction, V2_MetaFunction } from '@remix-run/node'
 import { Outlet } from '@remix-run/react'
 import type { ReactElement } from 'react'
 

--- a/app/routes/cookies.tsx
+++ b/app/routes/cookies.tsx
@@ -1,7 +1,13 @@
-import type { V2_MetaFunction } from '@remix-run/node'
+import type { HeadersFunction, V2_MetaFunction } from '@remix-run/node'
 import type { ReactElement } from 'react'
 
 import { Page } from '~/components/page'
+
+export const headers: HeadersFunction = () => {
+  return {
+    'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800'
+  }
+}
 
 export const meta: V2_MetaFunction = () => {
   return [

--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -1,7 +1,13 @@
-import type { V2_MetaFunction } from '@remix-run/node'
+import type { HeadersFunction, V2_MetaFunction } from '@remix-run/node'
 import type { ReactElement } from 'react'
 
 import { Page } from '~/components/page'
+
+export const headers: HeadersFunction = () => {
+  return {
+    'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800'
+  }
+}
 
 export const meta: V2_MetaFunction = () => {
   return [

--- a/app/routes/sitemap[.]xml.tsx
+++ b/app/routes/sitemap[.]xml.tsx
@@ -1,18 +1,35 @@
-import slugify from 'slugify'
+import type { HeadersFunction } from '@remix-run/node'
 
-import { Game } from '~/models/game'
+import { getCollection } from '~/db'
+import { GameService } from '~/services/game-service.server'
+
+export const headers: HeadersFunction = () => {
+  return {
+    'Content-Type': 'application/xml; charset=UTF-8',
+    'Cache-Control':
+      'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800'
+  }
+}
 
 export const loader = async () => {
-  const games = await Game.orderBy('name', 'desc').get()
+  const collection = await getCollection('games')
 
+  const games = (await collection
+    .find({})
+    .sort({ name: 1 })
+    .project({ _id: 0, gameId: 1, slug: 1 })
+    .toArray()) as { gameId: number; slug: string }[]
+
+  const gameCount = await new GameService().getGameCount()
   const pageSize = 48
-  const gameCount = await Game.orderBy('grossRevenue', 'desc').count()
   const pageCount = Math.ceil(gameCount / pageSize)
+
+  const lastmod = new Date().toISOString()
 
   const urlBlock = (path: string, priority = '1.0'): string => `
 <url>
   <loc>https://steam-revenue-calculator.com${path}</loc>
-  <lastmod>2023-09-28T09:59:59+02:00</lastmod>
+  <lastmod>${lastmod}</lastmod>
   <priority>${priority}</priority>
 </url>
   `
@@ -38,7 +55,6 @@ export const loader = async () => {
   ${urlBlock('/games')}
   ${urlBlock('/privacy')}
 
-  ${urlBlock('/blog')}
   ${urlBlock(
     '/blog/the-real-talk-on-steams-cut-what-your-game-actually-makes-and-why-its-complicated'
   )}
@@ -52,9 +68,9 @@ export const loader = async () => {
   return new Response(content, {
     status: 200,
     headers: {
-      'Content-Type': 'application/xml',
-      'xml-version': '1.0',
-      encoding: 'UTF-8'
+      'Content-Type': 'application/xml; charset=UTF-8',
+      'Cache-Control':
+        'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800'
     }
   })
 }

--- a/app/services/game-service.server.ts
+++ b/app/services/game-service.server.ts
@@ -47,9 +47,14 @@ export class GameService {
       1332010, 2230760, 646570, 567380, 1942280, 1708091, 379430, 488821, 322170
     ]
 
-    const games = await Game.whereIn('gameId', popularGameIds).get()
+    const collection = await getCollection('games')
 
-    return games.map((game) => game.details) as GameDetails[]
+    const games = (await collection
+      .find({ gameId: { $in: popularGameIds } })
+      .project({ _id: 0, details: 1 })
+      .toArray()) as { details: GameDetails }[]
+
+    return games.map((game) => game.details)
   }
 
   async migrateGamesToDatabase(): Promise<void> {

--- a/app/services/game-service.server.ts
+++ b/app/services/game-service.server.ts
@@ -1,5 +1,6 @@
 import { getCollection } from '~/db'
-import { createGameSlug, fetchGames, GameDetails } from '~/games'
+import type { GameDetails } from '~/games';
+import { createGameSlug, fetchGames } from '~/games'
 import { Game } from '~/models/game'
 import { calculateRevenue } from '~/revenue'
 
@@ -25,7 +26,7 @@ export class GameService {
       })
       .skip(skip)
       .limit(limit)
-      .toArray()) as Game[]
+      .toArray()) as { grossRevenue: number; details: GameDetails }[]
 
     return games.map((game) => ({ ...game.details, grossRevenue: game.grossRevenue }))
   }
@@ -36,9 +37,10 @@ export class GameService {
     }
 
     const collection = await getCollection('games')
-    cachedGameCount = await collection.estimatedDocumentCount()
+    const count = (await collection.estimatedDocumentCount()) as number
+    cachedGameCount = count
 
-    return cachedGameCount
+    return count
   }
 
   async listPopularGames(): Promise<GameDetails[]> {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
     "tqdm": "^2.0.3",
-    "vanilla-cookieconsent": "^3.1.0",
-    "yarn": "^1.22.19"
+    "vanilla-cookieconsent": "^3.1.0"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.19.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,17 @@
 {
   "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2019"],
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",
+    "module": "ES2022",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "target": "ES2019",
+    "target": "ES2020",
     "strict": true,
     "allowJs": true,
+    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9801,11 +9801,6 @@ yargs@^17.3.1:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
-yarn@^1.22.19:
-  version "1.22.19"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
-  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
-
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"


### PR DESCRIPTION
## Summary

A pass over the repo for Vercel-cost and page-load wins, plus cleanup to make `yarn typecheck`, `yarn test`, and `eslint` green again.

### Performance / resource usage
- **Sitemap caching + narrow queries** (`d8c8403`) — previously ran two unbounded queries on every crawler hit with no cache headers. Now projects only `gameId`/`slug`, reuses the cached game count, refreshes `lastmod`, and sets `s-maxage=86400` SWR=7d.
- **DB indexes** (`dcafdfe`) — only `grossRevenue` was indexed. Added unique `{gameId:1}` (the scraper's `findBy` hot path) and `{name:1}` (sitemap sort).
- **Cache headers on static routes** (`27efff2`) — home, about, blog, privacy, cookies, and per-game pages now send SWR-style `Cache-Control` so the edge serves them between function invocations.
- **`listPopularGames` projection** (`ab829f4`) — homepage no longer pulls full documents for 18 games on every hit.
- **DNS prefetch + dedupe analytics scripts** (`979e834`) — DNS warm-up for Google Tag Manager, AdSense, and the Steam CDN; module-scoped flag on `GoogleScripts` so consent toggles can't append duplicate `<script>` tags.
- **Remove `yarn` runtime dep** (`3deab52`) — was installed into the Vercel function bundle for no reason.
- **Node 20+** (`ba1a6d6`) — bumps `engines.node` off EOL Node 14.

### Security
- **Scrape auth key to env** (`77feae3`) — `/api/migrate-games` and `/api/scrape-games` no longer compare against a hardcoded literal. Reads `SCRAPE_KEY` and fails closed when unset. **Action required before deploy:** rotate the old literal (which is in git history) and set `SCRAPE_KEY` in Vercel; endpoints will 401 until you do.

### Toolchain cleanup
- **Type fixes** (`eafd6b2`) — `listGames` projection was cast to `Game[]` even though `Game.details` is optional, breaking the home-page test suite. Fixed the cast, returned a local in `getGameCount`, and bumped the tsconfig (`module: ES2022`, `skipLibCheck: true`) so the dynamic import in `cookie-consent.tsx` and the `@remix-run/node` fetch types both type-check.
- **Lint cleanup** (`34098ed`) — added `.eslintignore` (eliminated 25 errors / ~2300 warnings from `public/build/` output), dropped unused imports, switched type-only imports to `import type`, and spread `children` explicitly in `PaginationLink` for `jsx-a11y/anchor-has-content`.

### Explicitly deferred
- `mongodb` 3.6 → 6 driver upgrade — the `esix` ORM is pinned to mongodb 3.x's callback API; upgrading the driver requires replacing every `Game.findBy/whereIn/create/save` call. Worth a separate session.
- Removing `tqdm` — skipped per request.

## Test plan

- [x] `yarn typecheck` — 0 errors
- [x] `yarn test` — 9/9 tests, 3/3 suites
- [x] `npx eslint .` — 0 errors, 0 warnings
- [x] `yarn build` — succeeds
- [ ] Set `SCRAPE_KEY` env var in Vercel project (new rotated value), then verify `/api/scrape-games` still works
- [ ] Confirm sitemap cache headers land on the first preview deploy
- [ ] Spot-check CDN hit rate on `/games` and the per-game pages after deploy