### PR TITLE
docs: rewrite README for users, split dev notes into CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing
+
+## Tech stack
+
+- [Remix](https://remix.run/) on Node 20+
+- [MongoDB](https://www.mongodb.com/) via the [`esix`](https://www.npmjs.com/package/esix) ORM
+- [Tailwind CSS](https://tailwindcss.com/) + a few [shadcn/ui](https://ui.shadcn.com/) primitives
+- [Jest](https://jestjs.io/) + Testing Library
+- Deployed on [Vercel](https://vercel.com/)
+
+## Local setup
+
+```sh
+yarn install
+yarn dev
+```
+
+The dev server starts at <http://localhost:3000>.
+
+You'll need a MongoDB instance for the `/games` and per-game pages to show data — either a local `mongod` or a free MongoDB Atlas cluster. Without one the homepage still renders, just with no popular games.
+
+## Environment variables
+
+Create a `.env` file at the repo root:
+
+| Variable | Purpose | Example |
+|---|---|---|
+| `DB_URL` | MongoDB connection string | `mongodb://127.0.0.1:27017/` |
+| `DB_DATABASE` | Database name | `steam_revenue` |
+| `DB_POOL_SIZE` | Connection pool size (optional, defaults to 10) | `10` |
+| `SCRAPE_KEY` | Shared secret required by the scrape + migrate endpoints | any long random string |
+
+The scrape and migrate endpoints return 401 when `SCRAPE_KEY` is unset — that's intentional, not a bug.
+
+## Scripts
+
+```sh
+yarn dev         # Remix dev server with HMR
+yarn build       # production build
+yarn test        # Jest with coverage
+yarn typecheck   # tsc --noEmit
+npx eslint .     # lint
+```
+
+## Project layout
+
+```
+app/
+  components/    shared UI + shadcn primitives
+  db/            MongoDB client + index setup
+  games/         fetchGames(), slug helpers, GameDetails type
+  models/        esix models (Game)
+  revenue/       calculateRevenue(), revenueBreakdown()
+  routes/        Remix route modules
+  services/      higher-level server code (GameService)
+  tests/         jest tests for routes
+public/          static assets
+data/            local data files (e.g. ignored app IDs)
+```
+
+## The revenue formula
+
+The math lives in [`app/revenue/calculate-revenue.ts`](app/revenue/calculate-revenue.ts):
+
+- `calculateRevenue(reviews, price)` applies the Boxleiter multiplier for the review tier and multiplies by price.
+- `revenueBreakdown(grossRevenue)` subtracts regional pricing (~9%), discounts (~20%), refunds (~12%), then Steam's 30% cut and 20% VAT.
+
+Unit tests under `app/revenue/` cover the math — keep them green if you touch the formula.
+
+## Data pipeline
+
+Steam game data lives in MongoDB. Two admin endpoints keep it fresh, both gated behind `?key=<SCRAPE_KEY>`:
+
+- `GET /api/scrape-games?key=…&cursor=N` — fetches a small batch of games from Steam's `appdetails` API and upserts them. Paginated via `cursor` and rate-limited to roughly 2 seconds per game; designed to be called on a schedule.
+- `GET /api/migrate-games?key=…` — bulk load from a seed JSON file.
+
+Indexes on the `games` collection are created lazily by `ensureIndexes()` in [`app/db/index.ts`](app/db/index.ts) on the first request after a cold start.
+
+## Testing
+
+```sh
+yarn test
+```
+
+Runs Jest with coverage. New routes should get a smoke test following the pattern in `app/tests/routes/`.
+
+## Deployment
+
+`main` auto-deploys to Vercel. Production is at <https://steam-revenue-calculator.com>.
+
+Notes:
+
+- [`vercel.json`](vercel.json) sets the standard security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`).
+- [`server.ts`](server.ts) is the Remix adapter entry used by Vercel's Node runtime.
+- Route loaders set their own `Cache-Control` headers; edit the `headers` export on a route to tune caching.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,50 @@
 # Steam Revenue Calculator
 
-Estimates the revenue of games on Steam.
+Estimate how much any Steam game has earned.
 
-## Development
+**[steam-revenue-calculator.com](https://steam-revenue-calculator.com/)**
 
-To run your Remix app locally, make sure your project's local dependencies are
-installed:
+Plug in a game's review count and price, and the calculator returns an estimated gross revenue plus a breakdown of what the developer likely took home after Steam's cut, VAT, refunds, regional pricing, and sale discounts.
 
-```sh
-yarn install
-```
+## Who it's for
 
-Afterwards, start the Remix development server like so:
+- **Indie developers** sizing up similar titles before committing to a pitch, a price point, or a platform.
+- **Publishers and analysts** looking for a quick ballpark on a game or genre.
+- **Press and curious players** who want to know what a game actually made — not just how many copies it "sold".
 
-```sh
-yarn run dev
-```
+## How it works
 
-Open up [http://localhost:3000](http://localhost:3000) and you should be ready
-to go!
+The calculator uses the **Boxleiter method** — a well-known rule of thumb in game dev circles that estimates total sales from the number of reviews a game has on Steam. Different review tiers use different multipliers, because tiny games, mid-sized hits, and blockbusters all have very different review-to-sales ratios.
 
-If you're used to using the `vercel dev` command provided by
-[Vercel CLI](https://vercel.com/cli) instead, you can also use that, but it's
-not needed.
+Gross revenue comes from that estimate times the price. From there the breakdown subtracts the things that actually eat into a developer's take:
+
+- Regional pricing adjustments
+- Sale and launch discounts
+- Refunds
+- Steam's 30% revenue share
+- VAT
+
+What's left is the **net revenue** — what actually reaches the developer's account.
+
+## These are estimates, not audits
+
+A few things the method can't see:
+
+- Free-to-play games — the model doesn't apply.
+- Giveaways, bundles, and off-platform Steam key sales skew the numbers low.
+- A handful of outsized hits break the review curve.
+- Steam's cut drops to 25% above $10M and 20% above $50M; the calculator doesn't model those tier breaks yet.
+
+Treat the output as an order-of-magnitude guide.
+
+## Browse games
+
+The full [ranked list](https://steam-revenue-calculator.com/games) sorts thousands of Steam titles by estimated revenue. Click any game for its full breakdown.
+
+## Read more
+
+For a deeper look at what Steam's cut really costs and why "gross revenue" isn't what hits the developer's bank account, see [The Real Talk on Steam's Cut](https://steam-revenue-calculator.com/blog/the-real-talk-on-steams-cut-what-your-game-actually-makes-and-why-its-complicated).
+
+## Contributing
+
+Running the project locally, the tech stack, and the data pipeline are documented in [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

The current README is two paragraphs, both explaining how to run Remix locally. That's not what someone hitting the repo from the live site expects.

- Rewrite **README.md** for the actual audience — indie devs, publishers, and curious players — covering what the calculator does, who it's for, how the Boxleiter method works, what the breakdown subtracts, and the known limits of sales-from-reviews estimation. Link into [/games](https://steam-revenue-calculator.com/games) and the existing blog post.
- Move local setup, env vars, scripts, project layout, data pipeline, testing, and deployment notes into a new **CONTRIBUTING.md** so there's one place to look when working on the project.

## Test plan

- [x] README renders cleanly on GitHub
- [x] CONTRIBUTING renders cleanly on GitHub
- [x] All linked anchors/URLs resolve (live site, blog post, in-repo files)